### PR TITLE
fix #6: Introduce unordered arrays

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+1.2.1
+=====
+
+  * Proper Unicode support (https://github.com/supki/aeson-match-qq/pull/14)
+
 1.2.0
 =====
 

--- a/aeson-match-qq.cabal
+++ b/aeson-match-qq.cabal
@@ -1,10 +1,8 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.6.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 2cf49c3c176aae86e39190d8aeb04288afe12de46702d55f3587e474ea2b368a
 
 name:           aeson-match-qq
 version:        1.2.1
@@ -42,6 +40,7 @@ library
     , attoparsec
     , base >=4.11 && <5
     , bytestring
+    , containers
     , either
     , haskell-src-meta
     , scientific

--- a/aeson-match-qq.cabal
+++ b/aeson-match-qq.cabal
@@ -7,14 +7,14 @@ cabal-version: 1.12
 -- hash: 2cf49c3c176aae86e39190d8aeb04288afe12de46702d55f3587e474ea2b368a
 
 name:           aeson-match-qq
-version:        1.2.0
+version:        1.2.1
 synopsis:       Declarative JSON matchers.
 description:    See README.markdown
 category:       Web
 homepage:       https://github.com/supki/aeson-match-qq#readme
 bug-reports:    https://github.com/supki/aeson-match-qq/issues
 maintainer:     matvey.aksenov@gmail.com
-copyright:      Matvey Aksenov 2020
+copyright:      Matvey Aksenov 2022
 license:        BSD2
 license-file:   LICENSE
 build-type:     Simple

--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ library:
     - aeson
     - attoparsec
     - bytestring
+    - containers
     - either
     - haskell-src-meta
     - scientific

--- a/package.yaml
+++ b/package.yaml
@@ -1,10 +1,10 @@
 name: aeson-match-qq
-version: 1.2.0
+version: 1.2.1
 synopsis: Declarative JSON matchers.
 description: See README.markdown
 category: Web
 maintainer: matvey.aksenov@gmail.com
-copyright: Matvey Aksenov 2020
+copyright: Matvey Aksenov 2022
 license: BSD2
 extra-source-files:
   - README.markdown

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+{ pkgs ? import <nixpkgs> {}
+, ghc ? pkgs.haskell.compiler.ghc884
+, stack ? pkgs.stack
+}:
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    ghc
+    stack
+  ];
+
+  shellHook = ''
+  '';
+}

--- a/src/Aeson/Match/QQ.hs
+++ b/src/Aeson/Match/QQ.hs
@@ -18,6 +18,7 @@ module Aeson.Match.QQ
   ) where
 
 import           Data.String (IsString(..))
+import qualified Data.Text.Encoding as Text
 import           Language.Haskell.TH.Quote (QuasiQuoter(..))
 import           Language.Haskell.TH.Syntax (Lift(..))
 
@@ -29,7 +30,7 @@ import           Aeson.Match.QQ.Internal.Value (Value(..), Box(..), Array, Objec
 qq :: QuasiQuoter
 qq = QuasiQuoter
   { quoteExp = \str ->
-      case parse (fromString str) of
+      case parse (Text.encodeUtf8 (fromString str)) of
         Left err ->
           error ("Aeson.Match.QQ.qq: " ++ err)
         Right val ->

--- a/src/Aeson/Match/QQ/Internal/Match.hs
+++ b/src/Aeson/Match/QQ/Internal/Match.hs
@@ -24,7 +24,10 @@ import           Prelude hiding (any, null)
 import           Aeson.Match.QQ.Internal.Value (Value(..), Box(..), TypeSig(..), Type(..), Nullable(..))
 
 
-match :: Value Aeson.Value -> Aeson.Value -> Validation (NonEmpty VE) (HashMap Text Aeson.Value)
+match
+  :: Value Aeson.Value
+  -> Aeson.Value
+  -> Validation (NonEmpty VE) (HashMap Text Aeson.Value)
 match =
   go []
  where

--- a/src/Aeson/Match/QQ/Internal/Parse.hs
+++ b/src/Aeson/Match/QQ/Internal/Parse.hs
@@ -49,6 +49,8 @@ value = do
       string
     OpenSquareBracketP ->
       array
+    OpenParenP ->
+      arrayUO
     OpenCurlyBracketP ->
       object
     HashP ->
@@ -127,6 +129,17 @@ array = do
           }
       _ ->
         error "impossible"
+
+arrayUO :: Atto.Parser (Value Exp)
+arrayUO = do
+  _ <- Atto.word8 OpenParenP
+  spaces
+  _ <- Atto.string "unordered"
+  spaces
+  _ <- Atto.word8 CloseParenP
+  spaces
+  Array box <- array
+  pure (ArrayUO box)
 
 object :: Atto.Parser (Value Exp)
 object = do
@@ -226,9 +239,14 @@ pattern OpenSquareBracketP, CloseSquareBracketP :: Word8
 pattern OpenSquareBracketP = 91 -- '['
 pattern CloseSquareBracketP = 93 -- ']'
 
+pattern OpenParenP, CloseParenP :: Word8
+pattern OpenParenP = 40 -- '('
+pattern CloseParenP = 41 -- ')'
+
 pattern OpenCurlyBracketP, CloseCurlyBracketP, ColonP :: Word8
 pattern OpenCurlyBracketP = 123 -- '{'
 pattern CloseCurlyBracketP = 125 -- '}'
+
 pattern ColonP = 58 -- ':'
 
 pattern ZeroP, NineP, MinusP :: Word8

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.7
+resolver: lts-16.31
 packages:
   - '.'
 allow-newer: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 523700
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/7.yaml
-    sha256: 8e3f3c894be74d71fa4bf085e0a8baae7e4d7622d07ea31a52736b80f8b9bb1a
-  original: lts-14.7
+    size: 534126
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/16/31.yaml
+    sha256: 637fb77049b25560622a224845b7acfe81a09fdb6a96a3c75997a10b651667f6
+  original: lts-16.31

--- a/test/Aeson/Match/QQSpec.hs
+++ b/test/Aeson/Match/QQSpec.hs
@@ -118,6 +118,9 @@ spec = do
             , extendable = False
             })
 
+    it "#13" $
+      [qq| "Слава Україні" |] `shouldMatch` [aesonQQ| "Слава Україні" |]
+
 newtype ToEncoding a = ToEncoding { unToEncoding :: a }
     deriving (Show, Eq, Num)
 

--- a/test/Aeson/Match/QQSpec.hs
+++ b/test/Aeson/Match/QQSpec.hs
@@ -41,6 +41,15 @@ spec = do
       [qq| [1, _, 3, ...] |] `shouldBe`
         Array Box {knownValues = [Number 1, Any Nothing Nothing, Number 3], extendable = True}
 
+      [qq| (unordered) [] |] `shouldBe`
+        ArrayUO Box {knownValues = [], extendable = False}
+      [qq| (unordered) [1, 2, 3] |] `shouldBe`
+        ArrayUO Box {knownValues = [Number 1, Number 2, Number 3], extendable = False}
+      [qq| (unordered) [1, _, 3] |] `shouldBe`
+        ArrayUO Box {knownValues = [Number 1, Any Nothing Nothing, Number 3], extendable = False}
+      [qq| (unordered) [1, _, 3, ...] |] `shouldBe`
+        ArrayUO Box {knownValues = [Number 1, Any Nothing Nothing, Number 3], extendable = True}
+
       [qq| {} |] `shouldBe`
         Object Box {knownValues = [], extendable = False}
       [qq| {foo: 4} |] `shouldBe`
@@ -66,6 +75,13 @@ spec = do
       [qq| [1, 2, 3] |] `shouldMatch` [aesonQQ| [1, 2, 3] |]
       [qq| [1, _ : number, 3, ...] |] `shouldMatch` [aesonQQ| [1, 2, 3, 4] |]
       [qq| [1, _ : string] |] `shouldMatch` [aesonQQ| [1, "foo"] |]
+      [qq| (unordered) [] |] `shouldMatch` [aesonQQ| [] |]
+      [qq| (unordered) [1, 2, 3] |] `shouldMatch` [aesonQQ| [1, 2, 3] |]
+      [qq| (unordered) [1, 2, 3] |] `shouldMatch` [aesonQQ| [2, 3, 1] |]
+      [qq| (unordered) [1, 2, 2] |] `shouldMatch` [aesonQQ| [2, 2, 1] |]
+      [qq| (unordered) [1, _, 2] |] `shouldMatch` [aesonQQ| [2, 2, 1] |]
+      [qq| (unordered) [1, 2, ...] |] `shouldMatch` [aesonQQ| [2, 3, 1] |]
+      [qq| (unordered) [1, 2, ...] |] `shouldMatch` [aesonQQ| [2, 2, 1] |]
       [qq| {foo: 4, bar: 7} |] `shouldMatch` [aesonQQ| {foo: 4, bar: 7} |]
       [qq| {foo: 4, bar: 7, ...} |] `shouldMatch` [aesonQQ| {foo: 4, bar: 7, baz: 11} |]
       [qq| #{1 + 2 :: Int} |] `shouldMatch` [aesonQQ| 3 |]
@@ -81,6 +97,9 @@ spec = do
       [qq| [1, 2, 3, ...] |] `shouldNotMatch` [aesonQQ| [1, 2] |]
       [qq| [1, _ : string] |] `shouldNotMatch` [aesonQQ| [1, 2] |]
       [qq| [1, 2, 3, ...] |] `shouldNotMatch` [aesonQQ| [1, 2, 4] |]
+      [qq| (unordered) [1, 2, 3] |] `shouldNotMatch` [aesonQQ| [1, 2, 4] |]
+      [qq| (unordered) [1, 2, 3, 4] |] `shouldNotMatch` [aesonQQ| [1, 2, 3] |]
+      [qq| (unordered) [1, 2] |] `shouldNotMatch` [aesonQQ| [1, 2, 2] |]
       [qq| {foo: 4, bar: 7} |] `shouldNotMatch` [aesonQQ| {foo: 7, bar: 4} |]
       [qq| {foo: 4, bar: 7} |] `shouldNotMatch` [aesonQQ| {foo: 4, baz: 7} |]
       [qq| {foo: 4, bar: 7, ...} |] `shouldNotMatch` [aesonQQ| {foo: 4, baz: 11} |]
@@ -95,6 +114,13 @@ spec = do
     it "named holes" $ do
       match [qq| {foo: _hole} |] [aesonQQ| {foo: {bar: {baz: [1, 4]}}} |] `shouldBe`
         pure (HashMap.singleton "hole" [aesonQQ| {bar: {baz: [1, 4]}} |])
+
+    context "unordered array" $
+      it "named holes" $ do
+        match [qq| (unordered) [1, _hole] |] [aesonQQ| [2, 1] |] `shouldBe`
+          pure (HashMap.singleton "hole" [aesonQQ| 2 |])
+        match [qq| (unordered) [{foo: _hole}, ...] |] [aesonQQ| [{foo: 2}, 1] |] `shouldBe`
+          pure (HashMap.singleton "hole" [aesonQQ| 2 |])
 
     -- https://github.com/supki/aeson-match-qq/issues/7
     it "#7" $ do
@@ -118,6 +144,7 @@ spec = do
             , extendable = False
             })
 
+    -- https://github.com/supki/aeson-match-qq/issues/13
     it "#13" $
       [qq| "Слава Україні" |] `shouldMatch` [aesonQQ| "Слава Україні" |]
 


### PR DESCRIPTION
I've decided to go with the most explicit notation I could think of (`(unordered) [1,2,3]`); some shortcuts may be added later.